### PR TITLE
Update lens_zoom_pos range

### DIFF
--- a/E2/protocol/http.md
+++ b/E2/protocol/http.md
@@ -736,7 +736,7 @@ GET /ctrl/set?lens_zoom=stop
 ```HTTP
 GET /ctrl/set?lens_zoom_pos=0
 ```
-The range of the zoom position is 0-31
+The range of the zoom position is 0-255
 
 
 ## Magnify the preview


### PR DESCRIPTION
lens_zoom_pos value range from 0 to 255 according the camera.

{"code":0,"desc":"string","key":"lens_zoom_pos","type":2,"ro":0,"value":19,"min":0,"max":255,"step":1}